### PR TITLE
improving the reconciliation process (results in better ux)

### DIFF
--- a/src/components/bricks/Leaderboard/Container.tsx
+++ b/src/components/bricks/Leaderboard/Container.tsx
@@ -10,7 +10,7 @@ type Props = {
 const Container: FC<Props> = ({ teamName }) => {
   const [data, isFetching] = useLeaderboardData(teamName ?? null)
 
-  useFetchData()
+  useFetchData(teamName)
 
   const isLoading = isFetching && data.length === 0
 

--- a/src/components/bricks/Leaderboard/useFetchLeaderboardData.ts
+++ b/src/components/bricks/Leaderboard/useFetchLeaderboardData.ts
@@ -2,11 +2,11 @@ import { useDispatch } from 'react-redux'
 import { useEffect } from 'react'
 import * as TC from '../../../store/leaderboard/thunkCreators'
 
-const useFetchData = () => {
+const useFetchData = (myTeamName: string | undefined) => {
   const dispatch = useDispatch()
 
   const fetchData = () => {
-    dispatch(TC.fetchLeaderboard())
+    dispatch(TC.fetchLeaderboard({ myTeamName }))
   }
 
   useEffect(fetchData, [])

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,4 +11,4 @@ const applyConfig = () => {
 
 export default applyConfig
 
-export const CLICK_THROTTLE_TIMEOUT_MS = 350
+export const CLICK_DEBOUNCE_TIMEOUT_MS = 1500

--- a/src/store/_global/thunkCreators.ts
+++ b/src/store/_global/thunkCreators.ts
@@ -1,4 +1,4 @@
-import _throttle from 'lodash/throttle'
+import _debounce from 'lodash/debounce'
 import { ThunkCreator, ThunkDispatch } from '../types'
 import * as AC from './actionCreators'
 import * as R from '../../requests/recordClick'
@@ -6,7 +6,7 @@ import { handleRequestError, ReqErr } from '../../utils'
 import { getSessionString } from '../session/selectors'
 import { ClickScore } from '../../requests/types'
 import { fetchLeaderboard } from '../leaderboard/thunkCreators'
-import { CLICK_THROTTLE_TIMEOUT_MS } from '../../config'
+import { CLICK_DEBOUNCE_TIMEOUT_MS } from '../../config'
 
 type RecordClickParams = {
   teamName: string
@@ -14,9 +14,9 @@ type RecordClickParams = {
 
 type RecordClick = ThunkCreator<RecordClickParams>
 
-const refetchLeaderboardThrottled = _throttle(
-  (dispatch: ThunkDispatch) => dispatch(fetchLeaderboard()),
-  CLICK_THROTTLE_TIMEOUT_MS,
+const refetchLeaderboardDebounced = _debounce(
+  (dispatch: ThunkDispatch, myTeamName: string) => dispatch(fetchLeaderboard({ myTeamName })),
+  CLICK_DEBOUNCE_TIMEOUT_MS,
 )
 
 // eslint-disable-next-line import/prefer-default-export
@@ -32,7 +32,7 @@ export const recordClick: RecordClick = ({ teamName }) => (dispatch, getState) =
     }
 
     await R.recordClick(teamName, sessionString)
-      .then(() => refetchLeaderboardThrottled(dispatch))
+      .then(() => refetchLeaderboardDebounced(dispatch, teamName))
       .catch(onError)
   })
 }

--- a/src/store/leaderboard/reducer.ts
+++ b/src/store/leaderboard/reducer.ts
@@ -1,5 +1,6 @@
 import { reducer } from 'ts-action'
 import { on } from 'ts-action-immer'
+import _mapKeys from 'lodash/mapKeys'
 import * as AC from './actionCreators'
 import { Team } from '../../requests/types'
 import { recordClick, undoClick } from '../_global/actionCreators'
@@ -27,11 +28,7 @@ const leaderboardReducer = reducer(
   on(AC.getLeaderboardSuccess, (state, action) => {
     const { leaderboard } = action.payload
 
-    state.teamsByName = leaderboard.reduce((acc, curr) => {
-      acc[curr.team] = curr
-      return acc
-    }, {} as TeamsByName)
-
+    state.teamsByName = _mapKeys(leaderboard, val => val.team)
     state.teamNamesByOrder = leaderboard.map(({ team }) => team)
 
     state.isFetching = false

--- a/src/store/leaderboard/thunkCreators.ts
+++ b/src/store/leaderboard/thunkCreators.ts
@@ -1,11 +1,15 @@
 import { ThunkCreator } from '../types'
 import * as AC from './actionCreators'
-import { getIsLeaderboardFetching } from './selectors'
+import { getIsLeaderboardFetching, getTeamClicks } from './selectors'
 import { getLeaderboard } from '../../requests'
 import { handleRequestError } from '../../utils'
 
+type Params = {
+  myTeamName: string | undefined
+}
+
 // eslint-disable-next-line import/prefer-default-export
-export const fetchLeaderboard: ThunkCreator<void> = () => (dispatch, getState) => {
+export const fetchLeaderboard: ThunkCreator<Params> = ({ myTeamName }) => (dispatch, getState) => {
   return Promise.resolve().then(async () => {
     const isFetching = getIsLeaderboardFetching(getState())
     if (isFetching) return
@@ -13,7 +17,22 @@ export const fetchLeaderboard: ThunkCreator<void> = () => (dispatch, getState) =
     dispatch(AC.getLeaderboardRequest)
 
     getLeaderboard()
-      .then(res => dispatch(AC.getLeaderboardSuccess({ leaderboard: res.data })))
+      .then(res => {
+        const myTeamClicksStore = getTeamClicks(getState(), myTeamName ?? '')
+
+        if (!myTeamClicksStore) {
+          dispatch(AC.getLeaderboardSuccess({ leaderboard: res.data }))
+          return
+        }
+
+        // Do not decrease team clicks for stale leaderboard responses
+        const transformedLeaderboard = res.data.map(team => {
+          if (team.team !== myTeamName) return team
+          return { ...team, clicks: Math.max(team.clicks, myTeamClicksStore) }
+        })
+
+        dispatch(AC.getLeaderboardSuccess({ leaderboard: transformedLeaderboard }))
+      })
       .catch(e => {
         handleRequestError(e)
         dispatch(AC.getLeaderboardError())


### PR DESCRIPTION
stop team clicks going down for stale responses + debounce instead of throttle to minimize leaderboard position jitter